### PR TITLE
Fix streamlit part 5 error:  ArrowTypeError: ("Expected bytes, got a 'int' object", 'Conversion failed for column FG% with type object')

### DIFF
--- a/streamlit/part5/basketball_app.py
+++ b/streamlit/part5/basketball_app.py
@@ -17,6 +17,7 @@ st.sidebar.header('User Input Features')
 selected_year = st.sidebar.selectbox('Year', list(reversed(range(1950,2020))))
 
 # Web scraping of NBA player stats
+# year = 2020
 @st.cache
 def load_data(year):
     url = "https://www.basketball-reference.com/leagues/NBA_" + str(year) + "_per_game.html"
@@ -25,6 +26,9 @@ def load_data(year):
     raw = df.drop(df[df.Age == 'Age'].index) # Deletes repeating headers in content
     raw = raw.fillna(0)
     playerstats = raw.drop(['Rk'], axis=1)
+    playerstats.columns = [i.replace('%', '_percent') for i in playerstats.columns ]
+    for i in playerstats.filter(regex='percent').columns:
+        playerstats[i] = playerstats[i].astype(float)
     return playerstats
 playerstats = load_data(selected_year)
 
@@ -42,6 +46,8 @@ df_selected_team = playerstats[(playerstats.Tm.isin(selected_team)) & (playersta
 st.header('Display Player Stats of Selected Team(s)')
 st.write('Data Dimension: ' + str(df_selected_team.shape[0]) + ' rows and ' + str(df_selected_team.shape[1]) + ' columns.')
 st.dataframe(df_selected_team)
+# st.dataframe(df_selected_team.iloc[::,0:10])
+
 
 # Download NBA player stats data
 # https://discuss.streamlit.io/t/how-to-download-file-in-streamlit/1806
@@ -65,4 +71,4 @@ if st.button('Intercorrelation Heatmap'):
     with sns.axes_style("white"):
         f, ax = plt.subplots(figsize=(7, 5))
         ax = sns.heatmap(corr, mask=mask, vmax=1, square=True)
-    st.pyplot()
+    st.pyplot(f)

--- a/streamlit/part5/basketball_app.py
+++ b/streamlit/part5/basketball_app.py
@@ -17,7 +17,6 @@ st.sidebar.header('User Input Features')
 selected_year = st.sidebar.selectbox('Year', list(reversed(range(1950,2020))))
 
 # Web scraping of NBA player stats
-# year = 2020
 @st.cache
 def load_data(year):
     url = "https://www.basketball-reference.com/leagues/NBA_" + str(year) + "_per_game.html"
@@ -26,8 +25,7 @@ def load_data(year):
     raw = df.drop(df[df.Age == 'Age'].index) # Deletes repeating headers in content
     raw = raw.fillna(0)
     playerstats = raw.drop(['Rk'], axis=1)
-    playerstats.columns = [i.replace('%', '_percent') for i in playerstats.columns ]
-    for i in playerstats.filter(regex='percent').columns:
+    for i in playerstats.filter(regex='%').columns:
         playerstats[i] = playerstats[i].astype(float)
     return playerstats
 playerstats = load_data(selected_year)
@@ -46,7 +44,6 @@ df_selected_team = playerstats[(playerstats.Tm.isin(selected_team)) & (playersta
 st.header('Display Player Stats of Selected Team(s)')
 st.write('Data Dimension: ' + str(df_selected_team.shape[0]) + ' rows and ' + str(df_selected_team.shape[1]) + ' columns.')
 st.dataframe(df_selected_team)
-# st.dataframe(df_selected_team.iloc[::,0:10])
 
 
 # Download NBA player stats data


### PR DESCRIPTION
Since the versions of pandas and streamlit have been updated and do not accept the following data, so I made a little change to  deal with it in order to avoid error of  **ArrowTypeError: ("Expected bytes, got a 'int' object", 'Conversion failed for column FG% with type object')**

![image](https://user-images.githubusercontent.com/28496453/132981777-5d083693-a510-48eb-b3ad-33cf2a7be70c.png)

changed to 
![image](https://user-images.githubusercontent.com/28496453/132981858-36ea8116-2a70-49f1-86d0-a2e3c0987e31.png)

